### PR TITLE
Update pyo3 and switch from pyo3-pack to maturin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ script:
 
 deploy:
   - provider: script
-    script: docker run --rm -e PYO3_PACK_PASSWORD=${PYPI_PASSWORD} cbors-test:${PYTHON_VERSION}-${TRAVIS_COMMIT} pyo3-pack publish -u ${PYPI_USER}
+    script: docker run --rm -v ${TRAVIS_BUILD_DIR}/io -e MATURIN_PASSWORD=${PYPI_PASSWORD} konstin2/maturin publish -u ${PYPI_USER}
     on:
       tags: true
 
@@ -33,4 +33,5 @@ matrix:
   include:
     - env: PYTHON_VERSION=3.5 TOXENV=py35-nocov
     - env: PYTHON_VERSION=3.6 TOXENV=py36-nocov
-    - env: PYTHON_VERSION=3.7 TOXENV=py37-cov
+    - env: PYTHON_VERSION=3.7 TOXENV=py37-nocov
+    - env: PYTHON_VERSION=3.8 TOXENV=py38-cov

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,11 +18,11 @@ name = "cbors"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-pyo3 = { version = "0.7.0-alpha.1", features = ["extension-module"] }
+pyo3 = { version = "0.12", features = ["extension-module"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_cbor = "0.9"
 
-[package.metadata.pyo3-pack]
+[package.metadata.maturin]
 classifier = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",

--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ Recommended to install from [PyPI](https://pypi.org/project/cbors/), e.g.
 pip install cbors
 ```
 
-To install from source, use [pyo3-pack](https://github.com/PyO3/pyo3-pack) to build a wheel from repository root.
+To install from source, use [maturin](https://github.com/PyO3/maturin) to build a wheel from repository root.
 
 ```
-pyo3-pack build -i python3
+maturin build -i python3
 pip install target/wheels/*.whl
 ```
 
@@ -50,7 +50,7 @@ If this functionality is important to you, [cbor2](https://pypi.org/project/cbor
 
 ## Development
 
-For local development, it is recommended to create a virtual environment, and build the module via `pyo3-pack develop`.
+For local development, it is recommended to create a virtual environment, and build the module via `maturin develop`.
 
 A Dockerfile is provided which will build and install the module and run the test suite.
 

--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -42,7 +42,7 @@ RUN wget "https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rust
     rm rustup-init && \
     chmod -R a+w $RUSTUP_HOME $CARGO_HOME
 
-RUN pip3 install pyo3-pack tox
+RUN pip3 install maturin tox
 
 WORKDIR /usr/src/cbors
 COPY . ./

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["maturin"]
+build-backend = "maturin"

--- a/test/test_cbors.py
+++ b/test/test_cbors.py
@@ -5,14 +5,34 @@ import cbors
 import pytest
 
 from hypothesis import given, settings, HealthCheck
-from hypothesis.strategies import binary, booleans, dictionaries, floats, integers, lists, none, recursive, text
+from hypothesis.strategies import (
+    binary,
+    booleans,
+    dictionaries,
+    floats,
+    integers,
+    lists,
+    none,
+    recursive,
+    text,
+)
 
 i64 = integers(min_value=-9223372036854775808, max_value=9223372036854775807)
 u64 = integers(min_value=0, max_value=18446744073709551615)
 bytearrays = binary().map(bytearray)
 cbor_keys = none() | booleans() | i64 | text(printable) | binary()
-cbor_values = recursive(none() | booleans() | u64 | i64 | floats() | text(printable) | binary() | bytearrays,
-        lambda children: lists(children, 1) | dictionaries(cbor_keys, children, min_size=1))
+cbor_values = recursive(
+    none()
+    | booleans()
+    | u64
+    | i64
+    | floats()
+    | text(printable)
+    | binary()
+    | bytearrays,
+    lambda children: lists(children, min_size=1)
+    | dictionaries(cbor_keys, children, min_size=1),
+)
 
 
 def assert_equal(expected, actual):
@@ -41,7 +61,7 @@ def assert_equal(expected, actual):
 
 
 @given(cbor_values)
-@settings(suppress_health_check=(HealthCheck.too_slow, ))
+@settings(suppress_health_check=(HealthCheck.too_slow,))
 def test_decode_inverts_encode(v):
     assert_equal(v, cbors.loadb(cbors.dumpb(v)))
 
@@ -50,7 +70,7 @@ def test_invalid():
     with pytest.raises(TypeError):
         cbors.loadb(1)
     with pytest.raises(ValueError):
-        cbors.loadb(b'foo')
+        cbors.loadb(b"foo")
 
     class foo:
         pass
@@ -58,12 +78,12 @@ def test_invalid():
     with pytest.raises(TypeError):
         cbors.dumpb(foo())
     with pytest.raises(TypeError):
-        cbors.dumpb({'foo': foo()})
+        cbors.dumpb({"foo": foo()})
 
 
 def test_input_types():
-    cbors.loadb(b'\x01')
-    cbors.loadb(bytearray(b'\x01'))
+    cbors.loadb(b"\x01")
+    cbors.loadb(bytearray(b"\x01"))
     with pytest.raises(TypeError):
         cbors.loadb(1)
 
@@ -76,66 +96,59 @@ def test_rfc():
     examples = [
         (0, 0x00),
         (1, 0x01),
-        (10, 0x0a),
+        (10, 0x0A),
         (23, 0x17),
         (24, 0x1818),
         (25, 0x1819),
         (100, 0x1864),
-        (1000, 0x1903e8),
-        (1000000, 0x1a000f4240),
-        (1000000000000, 0x1b000000e8d4a51000),
-        (18446744073709551615, 0x1bffffffffffffffff),
+        (1000, 0x1903E8),
+        (1000000, 0x1A000F4240),
+        (1000000000000, 0x1B000000E8D4A51000),
+        (18446744073709551615, 0x1BFFFFFFFFFFFFFFFF),
         (-1, 0x20),
         (-10, 0x29),
         (-100, 0x3863),
-        (-1000, 0x3903e7),
-        (0.0, 0xf90000),
-        (-0.0, 0xf98000),
-        (1.0, 0xf93c00),
-        (1.1, 0xfb3ff199999999999a),
-        (1.5, 0xf93e00),
-        (65504.0, 0xf97bff),
-        (100000.0, 0xfa47c35000),
-        (3.4028234663852886e+38, 0xfa7f7fffff),
-        (1.0e+300, 0xfb7e37e43c8800759c),
-        (5.960464477539063e-8, 0xf90001),
-        (0.00006103515625, 0xf90400),
-        (-4.0, 0xf9c400),
-        (-4.1, 0xfbc010666666666666),
-        (float('inf'), 0xf97c00),
-        (float('nan'), 0xf97e00),
-        (float('-inf'), 0xf9fc00),
-        (False, 0xf4),
-        (True, 0xf5),
-        (None, 0xf6),
+        (-1000, 0x3903E7),
+        (0.0, 0xF90000),
+        (-0.0, 0xF98000),
+        (1.0, 0xF93C00),
+        (1.1, 0xFB3FF199999999999A),
+        (1.5, 0xF93E00),
+        (65504.0, 0xF97BFF),
+        (100000.0, 0xFA47C35000),
+        (3.4028234663852886e38, 0xFA7F7FFFFF),
+        (1.0e300, 0xFB7E37E43C8800759C),
+        (5.960464477539063e-8, 0xF90001),
+        (0.00006103515625, 0xF90400),
+        (-4.0, 0xF9C400),
+        (-4.1, 0xFBC010666666666666),
+        (float("inf"), 0xF97C00),
+        (float("nan"), 0xF97E00),
+        (float("-inf"), 0xF9FC00),
+        (False, 0xF4),
+        (True, 0xF5),
+        (None, 0xF6),
         ("", 0x60),
         ("a", 0x6161),
         ("IETF", 0x6449455446),
-        ("\"\\", 0x62225c),
-        ("\u00fc", 0x62c3bc),
-        ("\u6c34", 0x63e6b0b4),
+        ('"\\', 0x62225C),
+        ("\u00fc", 0x62C3BC),
+        ("\u6c34", 0x63E6B0B4),
         ([], 0x80),
         ([1, 2, 3], 0x83010203),
         ([1, [2, 3], [4, 5]], 0x8301820203820405),
-        (list(range(1, 26)),
-         0x98190102030405060708090a0b0c0d0e0f101112131415161718181819),
-        ({}, 0xa0),
-        ({
-            1: 2,
-            3: 4
-        }, 0xa201020304),
-        ({
-            "a": 1,
-            "b": [2, 3]
-        }, 0xa26161016162820203),
-        (["a", {
-            "b": "c"
-        }], 0x826161a161626163),
-        ({c: c.upper()
-          for c in 'abcde'}, 0xa56161614161626142616361436164614461656145),
+        (
+            list(range(1, 26)),
+            0x98190102030405060708090A0B0C0D0E0F101112131415161718181819,
+        ),
+        ({}, 0xA0),
+        ({1: 2, 3: 4}, 0xA201020304),
+        ({"a": 1, "b": [2, 3]}, 0xA26161016162820203),
+        (["a", {"b": "c"}], 0x826161A161626163),
+        ({c: c.upper() for c in "abcde"}, 0xA56161614161626142616361436164614461656145),
     ]
 
     for v, h in examples:
-        e = bytes.fromhex('{:02x}'.format(h))
+        e = bytes.fromhex("{:02x}".format(h))
         assert cbors.dumpb(v) == e
         assert_equal(v, cbors.loadb(e))

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
-envlist = py{35,36,37}-{cov,nocov}
+envlist = py{35,36,37,38}-{cov,nocov}
 skipsdist = true
 
 [testenv]
 whitelist_externals =
-    pyo3-pack
+    maturin
     rustup
     cov: bash
     cov: kcov
@@ -14,10 +14,10 @@ deps =
 passenv = TOXENV CI TRAVIS TRAVIS_* CODECOV_*
 commands_pre =
     rustup override set nightly
-    pyo3-pack develop
+    maturin develop
 commands_post =
     rustup override unset
 commands =
     nocov: pytest -v
-    cov: kcov --include-pattern=.rs --include-path={toxinidir} {envdir}/cov {basepython} -m pytest -v
+    cov: kcov --include-pattern=.rs --include-path={toxinidir} {envdir}/cov {envpython} -m pytest -v
     cov: bash -c "bash <(curl -s https://codecov.io/bash) -s {envdir}/cov"


### PR DESCRIPTION
Should resolve #2 

Updates pyo3 to 0.12, switches from pyo3-pack to maturin, uses the recommended docker image to build manylinux compatible wheels and includes python 3.8 in tests. Other small housekeeping done as well.